### PR TITLE
Always show current and next session of the day

### DIFF
--- a/src/components/pages/live/current-sessions/current-sessions.jsx
+++ b/src/components/pages/live/current-sessions/current-sessions.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+
+import { getSessionUrl } from '../../../../constants/sessionize-app';
+import { loadAllSessions } from '../../../shared/data/loadAllSessions';
+
+const getSessionTime = (session) => {
+  const start = new Date(session.startsAt);
+  const end = new Date(session.endsAt);
+
+  return `${start.getHours()}:${('0' + start.getMinutes()).slice(-2)} - ${end.getHours()}:${('0' + end.getMinutes()).slice(-2)}`;
+};
+
+const Session = ({ session }) => {
+  if (!session?.id) return;
+
+  return (
+    <div className="py-3">
+    <span className="text-sm font-bold bg-pink text-white py-1 px-2 rounded-full">
+       {getSessionTime(session)}
+      </span>
+      <p className="pt-1">
+        <a className="line-clamp-3" href={getSessionUrl(session.id)}>{session?.title}</a>
+      </p>
+    </div>
+  );
+};
+
+const SessionsForRoom = ({ roomName, allSessions }) => {
+  const currentTime = new Date();
+  const sessionsOfRoom = allSessions.find(s => s.groupName == roomName)?.sessions
+    .filter(s => new Date(s.startsAt).getDate() == currentTime.getDate())?? [];
+  const currentSession = sessionsOfRoom.filter(s => new Date(s.startsAt) <= currentTime)
+    .filter(s => new Date(s.endsAt) > currentTime)[0];
+  const nextSession = sessionsOfRoom.find(s => new Date(s.startsAt) > currentTime);
+
+  if(sessionsOfRoom.length == 0) return;
+
+  return (
+    <div className="col-span-1">
+      <h3>{roomName}</h3>
+      <Session session={currentSession} />
+      <Session session={nextSession} />
+      {(!currentSession && !nextSession) && (<p>all done for today</p>)}
+    </div>
+  );
+};
+
+const CurrentSessions = () => {
+  const allSessions = loadAllSessions();
+  const currentDate = new Date().getDate();
+  const isAnythingScheduledToday = allSessions.flatMap(group => group.sessions)
+    .some(session =>  new Date(session.startsAt).getDate() === currentDate);
+
+  if(!isAnythingScheduledToday) return <p>Nothing scheduled today</p>
+
+  return (
+    <div className="grid grid-cols-2 xs:grid-cols-1 gap-4">
+      <SessionsForRoom roomName={'Room 1'} allSessions={allSessions} />
+      <SessionsForRoom roomName={'Room 8'} allSessions={allSessions} />
+      <SessionsForRoom roomName={'Room 4'} allSessions={allSessions} />
+      <SessionsForRoom roomName={'Room 6'} allSessions={allSessions} />
+    </div>
+  );
+};
+
+export default CurrentSessions;

--- a/src/components/pages/live/live.jsx
+++ b/src/components/pages/live/live.jsx
@@ -3,14 +3,14 @@ import React from 'react';
 import { scheduleUrl } from '../../../constants/sessionize-app';
 import Button from '../../shared/button';
 
+import CurrentSessions from './current-sessions/current-sessions';
+
 const Live = () => (
-    <section className="safe-paddings container-md text-center grid grid-cols-2 sm:grid-cols-1 gap-4">
+    <section className="safe-paddings container-md text-center grid grid-cols-2 sm:grid-cols-1 gap-4 mb-4">
       <div className="col-span-2 sm:col-span-1 bg-gray-12 rounded-md p-2 flex-col inline-block justify-center">
-        <h2>Schedule</h2>
-        <p className="text-balance">
-          See the full schedule and mark talks you're interested in so you won't miss a session.
-        </p>
-        <Button to={scheduleUrl} className="my-6 mt-2">Full schedule</Button>
+        <h2 className="text-xl">Current and upcoming sessions</h2>
+        <CurrentSessions />
+        <Button to={scheduleUrl} className="my-4">See the full schedule</Button>
       </div>
 
       <div className="bg-gray-12 rounded-md p-2 flex-col inline-block justify-center">

--- a/src/components/shared/data/loadAllSessions.jsx
+++ b/src/components/shared/data/loadAllSessions.jsx
@@ -1,0 +1,21 @@
+import { useState, useEffect } from 'react';
+
+export const loadAllSessions = () => {
+  const [sessions, setSessions] = useState([]);
+
+  useEffect(() => {
+    const fetchSpeakers = async () => {
+      try {
+        const response = await fetch('https://sessionize.com/api/v2/dxat2zkl/view/Sessions');
+        const data = await response.json();
+        setSessions(data);
+      } catch (error) {
+        console.error('Error fetching sessions:', error);
+      }
+    };
+
+    fetchSpeakers();
+  }, []);
+
+  return sessions;
+};


### PR DESCRIPTION
This will show the current and upcoming session (given there are some on the current day) using the current time.
So on the 8th at 9:30 it would look like this 
![image](https://github.com/user-attachments/assets/dd820f0d-dda8-49e1-9100-fafba7dcb07c)

On the 9th at 9:30 like this
![image](https://github.com/user-attachments/assets/5fe9e87e-1c2f-4b2f-bef8-12ccdb1c44b1)

And on smaller screens like this
![image](https://github.com/user-attachments/assets/a68dc47e-c90e-4529-aab4-cadea85e72cd)
